### PR TITLE
Prepend rooturl to destination when using route as destination

### DIFF
--- a/Redirector.php
+++ b/Redirector.php
@@ -216,7 +216,7 @@ class Redirector extends BaseExtension
                 $routeMatcher = "~^route\:\s+?([a-z\-_]+)$~";
                 if (preg_match($routeMatcher, $self->destination, $matches)) {
                     if (isset($self->routes[$matches[1]])) {
-                        $self->destination = trim($self->routes[$matches[1]]['path'], '/');
+                        $self->destination = $app['paths']['rooturl'].trim($self->routes[$matches[1]]['path'], '/');
                     }
                 }
 


### PR DESCRIPTION
When using a route a destination the route path was used. However when
the website is not hosted in the web root but in a subfolder the
redirects failed. This prepends the rooturl so the roots will work
