### PR TITLE
Fix jump links

### DIFF
--- a/src/Redirector/Redirector.php
+++ b/src/Redirector/Redirector.php
@@ -33,14 +33,20 @@ class Redirector
      */
     public function handle(Request $request, Application $app)
     {
-
         $path = trim($request->getPathInfo(), '/');
         foreach ($this->config->getRedirects() as $redirect) {
 
             $redirect->prepare();
 
-            if($redirect->match($path)){
-                return $app->redirect('/' . $redirect->getResult($path), 301);
+            if ($redirect->match($path)) {
+                $result = $redirect->getResult($path);
+
+                // Only prefix Bolt redirects
+                if (substr($result, 0, 4 ) !== "http") {
+                    $result = '/' . $result;
+                }
+
+                return $app->redirect($result, 301);
             }
         }
     }

--- a/src/Redirector/Redirector.php
+++ b/src/Redirector/Redirector.php
@@ -42,7 +42,7 @@ class Redirector
                 $result = $redirect->getResult($path);
 
                 // Only prefix Bolt redirects
-                if (substr($result, 0, 4 ) !== "http") {
+                if (!preg_match("~^(https?|ftps?)\://~", $result)) {
                     $result = '/' . $result;
                 }
 


### PR DESCRIPTION
This fixes an issue with [jump links](https://github.com/SahAssar/boltredirector/wiki#jump-links) when using a domain to redirect to. Currently all redirects get prefixed with a forward slash. It looks like jump link is some [old functionality](https://github.com/SahAssar/boltredirector/blob/562395e5b15e6bbdfb1b52e15abf8d3281189355/Redirector/extension.php#L235) that got missed when refactoring the code.

In boltredirector.sahassar.yml:
```
redirectfoo:
    from: '/foo/{slug:segment}'
    to: 'https://example.com/{slug}'
```

Before:
```
< HTTP/1.1 301 Moved Permanently
< Location: /https://example.com/bar
< Content-Type: text/html; charset=UTF-8
```

After:
```
< HTTP/1.1 301 Moved Permanently
< Location: https://example.com/bar
< Content-Type: text/html; charset=UTF-8
```