### PR TITLE
Fixed bug

### DIFF
--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -101,6 +101,6 @@ class Config extends ParameterBag
      */
     public function get($key, $default = null, $deep = false)
     {
-        return parent::get($key, $default = [], $deep);
+        return (array) parent::get($key, $default, $deep);
     }
 }


### PR DESCRIPTION
Different approach on forcing array returns,

Because this:
`variables:`

Will result in the parameterbag returning a null instead of the given default. The default is only returned if there is nothing at all